### PR TITLE
헤로쿠로 배포

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: java -Dserver.port=8080 -Dspring.profiles.active=production -jar build/libs/ofcors-0.0.1-SNAPSHOT.jar

--- a/src/main/java/kr/heyjyu/ofcors/OfcorsApplication.java
+++ b/src/main/java/kr/heyjyu/ofcors/OfcorsApplication.java
@@ -51,7 +51,9 @@ public class OfcorsApplication {
 
 			@Override
 			public void addCorsMappings(CorsRegistry registry) {
-				registry.addMapping("/**").allowedOrigins("*").allowedMethods("*");
+				registry.addMapping("/**")
+						.allowedOrigins("*")
+						.allowedMethods("*");
 			}
 
 			@Override

--- a/system.properties
+++ b/system.properties
@@ -1,0 +1,1 @@
+java.runtime.version=17


### PR DESCRIPTION
fly.io는 프록시를 거쳐 오기 때문에 외부 API 리디렉션 시 CORS에러가 발생하여 헤로쿠로 배포한다.